### PR TITLE
Allow non-binary incidence

### DIFF
--- a/docs/software.rst
+++ b/docs/software.rst
@@ -234,3 +234,5 @@ Release Notes
   * v0.3.4 - add survey weighting use case
   * v0.3.5 - add Python 3.5+ support
   * v0.4 - transfer to ActivitySim.org
+  * v0.4.1 - package updates
+  * v0.4.2 - validation script in Python

--- a/populationsim/balancer.py
+++ b/populationsim/balancer.py
@@ -208,7 +208,7 @@ def np_balancer(
                     yy + relaxed_constraint / float(importance))
 
             # update HH weights
-            weights_final[incidence[c] > 0] *= gamma[c]
+            weights_final *= pow(gamma[c], incidence[c])
 
             # clip weights to upper and lower bounds
             weights_final = np.clip(weights_final, weights_lower_bound, weights_upper_bound)

--- a/populationsim/simul_balancer.py
+++ b/populationsim/simul_balancer.py
@@ -238,7 +238,7 @@ def np_simul_balancer(
                         yy + (relaxed_constraint / float(importance)))
 
                 # update HH weights
-                sub_weights[z][incidence[c] > 0] *= gamma[z, c]
+                sub_weights[z] *= pow(gamma[z,c], incidence[c])
 
                 # clip weights to upper and lower bounds
                 sub_weights[z] = np.clip(sub_weights[z], weights_lower_bound, weights_upper_bound)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='populationsim',
-    version='0.4.1',
+    version='0.4.2',
     description='Population Synthesis',
     author='contributing authors',
     author_email='ben.stabler@rsginc.com',


### PR DESCRIPTION
This PR updates the list_balancer and simultaneous_list_balancer to allow for non-binary incidences. 

In particular it changes the household weight updating to use a power in line with Equation 13 in Peter Vovsha's 2014 paper which uses a similar methodology. 

![image](https://user-images.githubusercontent.com/151124/81893642-5ab9bb80-95f1-11ea-939e-c933f2d43ac9.png)

https://pdfs.semanticscholar.org/f765/07c2b1f534dcb4ca281681080ba2f15140d8.pdf

With this change, household size can be directly included as a control total rather than encoding via a series of dummy variables

```csv
target,geography,seed_table,importance,control_field,expression
num_opd,TZ16,households,100000000,num_opd,(households.weight > 0) & (households.weight < np.inf)
pop_opd,TZ16,persons,100000000000,pop_opd,persons.REGION == 1
```